### PR TITLE
ci: run CI on PRs to any branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,9 @@
 name: Test and Deploy
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
+    branches:
+      - "**"
 
 jobs:
   test:


### PR DESCRIPTION
With a new `develop` git workflow it turned out Actions don't run on PRs to branches except for `main`.

Closes #137