### PR TITLE
chore: bump `@tact-lang/compiler` to 1.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@monaco-editor/react": "^4.5.1",
         "@nowarp/misti": "^0.6.1",
         "@orbs-network/ton-access": "^2.3.0",
-        "@tact-lang/compiler": "^1.5.3",
+        "@tact-lang/compiler": "^1.5.4",
         "@ton-community/func-js": "^0.5.0",
         "@ton/core": "^0.56.3",
         "@ton/sandbox": "^0.20.0",
@@ -1450,9 +1450,9 @@
       }
     },
     "node_modules/@tact-lang/compiler": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@tact-lang/compiler/-/compiler-1.5.3.tgz",
-      "integrity": "sha512-BxSCWfIQJUa0RC2ZltYfgTeN+3dRjMs4Hdxq61REfghpRiSU0IKdkLPGqJH/5zimzFFhjD4mhR0aFS71zUH9hA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@tact-lang/compiler/-/compiler-1.5.4.tgz",
+      "integrity": "sha512-r47LoKG458EbFoAz01AT77J7ymhDr1soBRZWZayEuBLWkxMRuK8IKWZb5hiQH1u8sCOankNtJjtVbxXmsb8SdA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@monaco-editor/react": "^4.5.1",
     "@nowarp/misti": "^0.6.1",
     "@orbs-network/ton-access": "^2.3.0",
-    "@tact-lang/compiler": "^1.5.3",
+    "@tact-lang/compiler": "^1.5.4",
     "@ton-community/func-js": "^0.5.0",
     "@ton/core": "^0.56.3",
     "@ton/sandbox": "^0.20.0",


### PR DESCRIPTION
Resolves #292 