### PR TITLE
Fix dependabot `versioning-strategy` setting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/" 
+    directory: "/"
+    versioning-strategy: "auto"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 5  
+    open-pull-requests-limit: 5
     allow:
       - dependency-name: "@tact-lang/compiler"
-        versioning-strategy: "auto"


### PR DESCRIPTION
This allow dependabot to update compiler in WebIDE to new version automatically in PR

Example

<img width="933" alt="image" src="https://github.com/user-attachments/assets/54bef20a-22c6-49d5-8150-4a61557796fc" />
