### PR TITLE
TON Sandbox declaration filename fix for editor support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@isomorphic-git/lightning-fs": "^4.6.0",
         "@minoru/react-dnd-treeview": "^3.4.1",
         "@monaco-editor/react": "^4.5.1",
-        "@nowarp/misti": "^0.9.0",
+        "@nowarp/misti": "0.9.0",
         "@orbs-network/ton-access": "^2.3.0",
         "@tact-lang/compiler": "^1.6.13",
         "@ton-community/func-js": "^0.9.1",

--- a/src/components/workspace/Editor/EditorOnMount.ts
+++ b/src/components/workspace/Editor/EditorOnMount.ts
@@ -114,6 +114,6 @@ export const editorOnMount = async (monaco: Monaco) => {
   );
   monaco.languages.typescript.typescriptDefaults.addExtraLib(
     tonSanboxText,
-    'file:///node_modules/@types/ton-community__sandbox/index.d.ts',
+    'file:///node_modules/@types/ton__sandbox/index.d.ts',
   );
 };


### PR DESCRIPTION
When editing TypeScript files (tests), the hints for the `@ton/sandbox` library do not work. To fix this, you need to change the path to the `index.d.ts` file (`ton-community` to `ton`).

Bug reproduction:
<img src="https://github.com/user-attachments/assets/09a0cb25-a0ec-4b4d-8d27-84fb96d6f5ea" width="512"></img>

Fix reproduction:
<img src="https://github.com/user-attachments/assets/2be1d3ee-1db0-4826-b3f1-33e06fe96e45" width="512"></img>

